### PR TITLE
Properly type request values

### DIFF
--- a/datatables/datatables.py
+++ b/datatables/datatables.py
@@ -60,7 +60,16 @@ class DataTables:
     def __init__(self, request, sqla_object, query, columns):
         """Initializes the object with the attributes needed, and runs the query
         """
-        self.request_values = request.GET
+        self.request_values = dict(request.GET)
+
+        for key, value in self.request_values.items():
+            try:
+                self.request_values[key] = int(value)
+            except ValueError:
+                if value in ("true", "false"):
+                    self.request_values[key] = value == "true"
+                
+                
         self.sqla_object = sqla_object
         self.query = query
         self.columns = columns


### PR DESCRIPTION
On Python 3.4 the sorting() function fails on "self.request_values.get('iSortingCols') > 0:", because it cannot compare a string to an integer. Rather than just wrap an int() around it this patch turns self.request_values into a dictionary and applies the correct types to all values.
