### PR TITLE
Fix: made the module available for Flask and other frameworks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ A simple example
         query = DBSession.query(User).join(Address).filter(Address.id > 14)
 
         # instantiating a DataTable for the query and table needed
-        rowTable = DataTables(request, User, query, columns)
+        rowTable = DataTables(request.GET, User, query, columns)
 
         # returns what is needed by DataTable
         return rowTable.output_result()

--- a/datatables/datatables.py
+++ b/datatables/datatables.py
@@ -84,15 +84,7 @@ class DataTables:
     def __init__(self, request, sqla_object, query, columns):
         """Initializes the object with the attributes needed, and runs the query
         """
-        self.request_values = dict(request.GET)
-
-        for key, value in self.request_values.items():
-            try:
-                self.request_values[key] = int(value)
-            except ValueError:
-                if value in ("true", "false"):
-                    self.request_values[key] = value == "true"
-
+        self.request_values = DataTables.prepare_arguments(request)
         self.sqla_object = sqla_object
         self.query = query
         self.columns = columns
@@ -152,6 +144,19 @@ class DataTables:
             formatted_results.append(row)
 
         self.results = formatted_results
+
+    @classmethod
+    def prepare_arguments(cls, request):
+        request_values = dict()
+        for key, value in request.items():
+            try:
+                request_values[key] = int(value)
+            except ValueError:
+                if value in ("true", "false"):
+                    request_values[key] = value == "true"
+                else: # assume string
+                    request_values[key] = value
+        return request_values
 
     def filtering(self):
         """Construct the query, by adding filtering(LIKE) on all

--- a/test-project/testproject/views.py
+++ b/test-project/testproject/views.py
@@ -59,7 +59,7 @@ def simple_example(request):
     query = DBSession.query(User).join(Address).filter(Address.id > 14)
 
     # instantiating a DataTable for the query and table needed
-    rowTable = DataTables(request, User, query, columns)
+    rowTable = DataTables(request.GET, User, query, columns)
 
     # returns what is needed by DataTable
     return rowTable.output_result()


### PR DESCRIPTION
WARNING! This patch changes API!

In this patch changes the type of 'request' argument for DataTables constructor. Now it accept the MultiDict (not 'request' itself) to work with any web-framework. (Pyramid uses request.GET with [pyramid.interfaces.IMultiDict] (http://docs.pylonsproject.org/projects/pyramid//en/latest/api/interfaces.html#pyramid.interfaces.IMultiDict) type, Flask uses request.args with [werkzeug.datastructures.MultiDict] (http://werkzeug.pocoo.org/docs/0.10/datastructures/#werkzeug.datastructures.MultiDict). Both supports .items() method for iterating)