### PR TITLE
Fix to handle as None when a request value is empty string

### DIFF
--- a/datatables/datatables.py
+++ b/datatables/datatables.py
@@ -92,6 +92,8 @@ class DataTables:
             except ValueError:
                 if value in ("true", "false"):
                     self.request_values[key] = value == "true"
+                elif value == '':
+                    self.request_values[key] = None
 
         self.sqla_object = sqla_object
         self.query = query


### PR DESCRIPTION
I tried to start test-project, but no data have shown. It seems datatables handles None instead of empty string. So it queries empty string as sql conditions as below.

* Before fix

```
2015-07-29 09:11:39,313 INFO  [sqlalchemy.engine.base.Engine][Dummy-2] SELECT users.id AS users_id, users.name AS users_name, users.created_at AS users_created_at 
FROM users JOIN addresses ON users.id = addresses.user_id 
WHERE addresses.id > ? AND CAST(users.id AS VARCHAR) = ? AND CAST(users.id AS VARCHAR) = ? AND CAST(users.name AS VARCHAR) = ? AND CAST(users.id AS VARCHAR) = ? AND CAST(users.name AS VARCHAR) = ? AND CAST(addresses.description AS VARCHAR) = ? AND CAST(users.id AS VARCHAR) = ? AND CAST(users.name AS VARCHAR) = ? AND CAST(addresses.description AS VARCHAR) = ? AND CAST(users.created_at AS VARCHAR) = ? ORDER BY users.id ASC
 LIMIT ? OFFSET ?
2015-07-29 09:11:39,313 INFO  [sqlalchemy.engine.base.Engine][Dummy-2] (14, u'', u'', u'', u'', u'', u'', u'', u'', u'', u'', 10, 0)
```

* After fix

```
2015-07-29 09:14:47,978 INFO  [sqlalchemy.engine.base.Engine][Dummy-2] SELECT users.id AS users_id, users.name AS users_name, users.created_at AS users_created_at 
FROM users JOIN addresses ON users.id = addresses.user_id 
WHERE addresses.id > ? ORDER BY users.id ASC
 LIMIT ? OFFSET ?
2015-07-29 09:14:47,978 INFO  [sqlalchemy.engine.base.Engine][Dummy-2] (14, 10, 0)
```

My environment is here.

```sh
(pyramid)$ python --version
Python 2.7.10
(pyramid)$ pip freeze
Chameleon==2.22
Mako==1.0.1
MarkupSafe==0.23
PasteDeploy==1.5.2
Pygments==2.0.2
pyramid==1.5.7
pyramid-chameleon==0.3
pyramid-debugtoolbar==2.4
pyramid-mako==1.0.2
pyramid-tm==0.12
repoze.lru==0.6
SQLAlchemy==1.0.8
-e git+git@github.com:t2y/sqlalchemy-datatables.git@1a6a562e01543e0ef1a6d48a3c9a13398746c22e#egg=sqlalchemy_datatables-master
test-project==0.0
transaction==1.4.4
translationstring==1.3
venusian==1.0
waitress==0.8.9
WebOb==1.4.1
wheel==0.24.0
zope.deprecation==4.1.2
zope.interface==4.1.2
zope.sqlalchemy==0.7.6
```