### PR TITLE
Fixes: sorting on first column and no filter if None value

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -283,7 +283,7 @@ class DataTables:
             dirOrder = 'order[%s][dir]'
 
         i = 0
-        if self.request_values.get(columnOrder % i):
+        if self.request_values.get(columnOrder % i) is not None:
             sorting.append(
                 Order(self.columns[int(
                       self.request_values[columnOrder % i])]

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -242,7 +242,7 @@ class DataTables:
             search_value2 = self.request_values.get(
                 searchableColumnValue % idx)
 
-            if search_value2 is not None:
+            if search_value2:
                 sqla_obj, column_name = search(idx, col)
 
                 if col.search_like:

--- a/tests/test_datatables.py
+++ b/tests/test_datatables.py
@@ -252,6 +252,16 @@ class DataTablesTest(unittest.TestCase):
 
         assert res['data'][0]['1'] == '000_aaa'
 
+        # DESC first column
+        req = self.create_dt_params(order=[{"column": 0, "dir": "desc"}])
+
+        rowTable = DataTables(
+            req, User, self.session.query(User).join(Address), columns)
+
+        res = rowTable.output_result()
+
+        assert res['data'][0]['1'] == 'zzz_aaa'
+        
     def test_column_ordering_relation(self):
         """Test if a foreign key column is orderable."""
         self.populate(5)

--- a/tests/test_datatables.py
+++ b/tests/test_datatables.py
@@ -218,6 +218,29 @@ class DataTablesTest(unittest.TestCase):
         assert res['recordsTotal'] == '7'
         assert res['recordsFiltered'] == '0'
 
+    def test_null_field_filtering(self):
+        """Test if a None field is not filtered."""
+        self.populate(5)
+
+        user6, addr6 = self.create_user('Empty', None)
+
+        self.session.add(user6)
+        self.session.commit()
+
+        columns = self.create_columns(['id', 'name', 'address.description',
+                                       'created_at'])
+        
+        req = self.create_dt_params()
+
+        rowTable = DataTables(
+            req, User, self.session.query(User).join(Address), columns)
+
+        res = rowTable.output_result()
+
+        assert len(res['data']) == 6
+        assert res['recordsTotal'] == '6'
+        assert res['recordsFiltered'] == '6'
+        
     def test_column_ordering(self):
         """Test if a column is orderable."""
         self.populate(5)


### PR DESCRIPTION
Hello,
Thanks for your module. Greatly appreciated!

I found two minor bugs: 
1. Sorting on first column does not work since self.request_values.get(columnOrder % i) = 0 and is evaluated as False. 
2. Tables containing None values are filtered even if "column[x][search][value]" is empty. 