### PR TITLE
allow filter based on row data

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2rc1
 files = setup.py
 

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -180,7 +180,7 @@ class DataTables:
                     elif col.filterarg == 'row':
                         tmp_row = col.filter(self.results[i])
                     else:
-                        raise invalidParameter, "invalid filterarg {} for column_name {}: filterarg must be 'row' or 'cell'".format(col.filterarg, col.column_name)
+                        raise invalidParameter("invalid filterarg %s for column_name %s: filterarg must be 'row' or 'cell'" % col.filterarg, col.column_name)
                 else:
                     tmp_row = get_attr(self.results[i], col.column_name)
                 row[col.mData if col.mData else str(j)] = tmp_row

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -16,9 +16,11 @@ log = getLogger(__file__)
 if sys.version_info > (3, 0):
     unicode = str
 
+class invalidParameter(Exception): pass
+
 ColumnTuple = namedtuple(
     'ColumnDT',
-    ['column_name', 'mData', 'search_like', 'filter', 'searchable'])
+    ['column_name', 'mData', 'search_like', 'filter', 'searchable', 'filterarg'])
 
 
 def get_attr(sqla_object, attribute):
@@ -51,19 +53,21 @@ class ColumnDT(ColumnTuple):
     :param searchable: Enable or disable a column to be searchable
         server-side. (default True)
     :type searchable: bool
+    :param filterarg: type of argument for filter function
+    :type filterarg: string: 'cell' or 'row'. 'cell' is default
 
     :returns: a ColumnDT object
     """
 
     def __new__(cls, column_name, mData=None, search_like=True,
-                filter=str, searchable=True):
+                filter=str, searchable=True, filterarg='cell'):
         """Set default values for mData and filter.
 
         On creation, sets default None values for mData and string value for
         filter (cause: Object representation is not JSON serializable).
         """
         return super(ColumnDT, cls).__new__(
-            cls, column_name, mData, search_like, filter, searchable)
+            cls, column_name, mData, search_like, filter, searchable, filterarg)
 
 
 class DataTables:
@@ -166,12 +170,19 @@ class DataTables:
             row = dict()
             for j in range(len(self.columns)):
                 col = self.columns[j]
-                tmp_row = get_attr(self.results[i], col.column_name)
                 if col.filter:
-                    if sys.version_info < (3, 0) \
-                            and hasattr(tmp_row, 'encode'):
-                        tmp_row = col.filter(tmp_row.encode('utf-8'))
-                    tmp_row = col.filter(tmp_row)
+                    if col.filterarg == 'cell':
+                        tmp_row = get_attr(self.results[i], col.column_name)
+                        if sys.version_info < (3, 0) \
+                                and hasattr(tmp_row, 'encode'):
+                            tmp_row = col.filter(tmp_row.encode('utf-8'))
+                        tmp_row = col.filter(tmp_row)
+                    elif col.filterarg == 'row':
+                        tmp_row = col.filter(self.results[i])
+                    else:
+                        raise invalidParameter, "invalid filterarg {} for column_name {}: filterarg must be 'row' or 'cell'".format(col.filterarg, col.column_name)
+                else:
+                    tmp_row = get_attr(self.results[i], col.column_name)
                 row[col.mData if col.mData else str(j)] = tmp_row
             formatted_results.append(row)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 
-__VERSION__ = '0.2.1'
+__VERSION__ = '0.2.2rc1'
 
 
 setup(


### PR DESCRIPTION
* new parameter filterarg
* filterarg = 'cell' is default with filter=f(cell) as in 0.2.1
* filterarg = 'row' allows filter=f(row) for more complex filtering
* fixes https://github.com/Pegase745/sqlalchemy-datatables/issues/38