### PR TITLE
patch for sql order_by query

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -438,7 +438,7 @@ class DataTables:
                     else:
                         tablename = parent.__table__.name
 
-            sort_name = '%s.%s' % (tablename, sort_name)
+            sort_name = '%s.%s' % ('"'+tablename+'"', sort_name)
 
             ordering = asc(text(sort_name)) if sort.dir == 'asc' else desc(
                 text(sort_name))

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -438,7 +438,7 @@ class DataTables:
                     else:
                         tablename = parent.__table__.name
 
-            sort_name = '%s.%s' % ('"'+tablename+'"', sort_name)
+            sort_name = '%s.%s' % (tablename, sort_name)
 
             ordering = asc(text(sort_name)) if sort.dir == 'asc' else desc(
                 text(sort_name))

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -37,7 +37,7 @@ def get_attr(sqla_object, attribute):
     output = sqla_object
     for x in attribute.split('.'):
         if type(output) is InstrumentedList:
-            output = ', '.join([getattr(elem, x) for elem in output])
+            output = ', '.join([str(getattr(elem, x)) for elem in output])
         else:
             output = getattr(output, x, None)
     return output


### PR DESCRIPTION
Using PSQL and a table name like Tables1 (note the capital T), the sql query will fail if the ORDER_BY table specified is not enclosed in quotes. This is a patch to ensure that said table will be quoted.
