### PR TITLE
Added double quotes for case-sensitive table names

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -438,7 +438,7 @@ class DataTables:
                     else:
                         tablename = parent.__table__.name
 
-            sort_name = '%s.%s' % (tablename, sort_name)
+            sort_name = '"%s".%s' % (tablename, sort_name)
 
             ordering = asc(text(sort_name)) if sort.dir == 'asc' else desc(
                 text(sort_name))


### PR DESCRIPTION
When converted to SQL, double quotes are needed for table names with capitals or special characters. #59
