### PR TITLE
Cast regex to string to allow searching of numerical values

### DIFF
--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -52,7 +52,7 @@ def clean_regex(regex):
     :rtype: str with regex to use with database
     '''
     # copy for return
-    ret_regex = regex
+    ret_regex = str(regex)
 
     # these characters are escaped (all except alternation | and escape \)
     # see http://www.regular-expressions.info/refquick.html


### PR DESCRIPTION
When using this with Django and searching for numerical values, this error arises:

```
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python2.7/dist-packages/datatables/__init__.py", line 172, in __init__
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/datatables/__init__.py", line 223, in run
    self.filtering()
  File "/usr/local/lib/python2.7/dist-packages/datatables/__init__.py", line 319, in filtering
    regex = clean_regex(searchValue)
  File "/usr/local/lib/python2.7/dist-packages/datatables/__init__.py", line 62, in clean_regex
    ret_regex = ret_regex.replace('\\','')
AttributeError: 'int' object has no attribute 'replace'
```

This casts the regex to a string to avoid this error.
