### PR TITLE
Allow yadcf range #58

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.4.1lk
+current_version = 0.4.1lk2
 files = setup.py
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1lk
 files = setup.py
 

--- a/datatables/__init__.py
+++ b/datatables/__init__.py
@@ -498,5 +498,5 @@ class DataTables:
             pages.start = int(self.request_values[displayStart])
             pages.length = int(self.request_values[displayLength])
 
-        offset = pages.start + pages.length
-        self.query = self.query.slice(pages.start, offset)
+            offset = pages.start + pages.length
+            self.query = self.query.slice(pages.start, offset)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 
-__VERSION__ = '0.4.0'
+__VERSION__ = '0.4.1lk'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 
-__VERSION__ = '0.4.1lk'
+__VERSION__ = '0.4.1lk3'
 
 
 setup(


### PR DESCRIPTION
This allows https://github.com/vedmack/yadcf to send range of dates or numbers to be retrieved properly. yadcf assumes a particular delimiter string which is sent between the range values, but this could easily be modified to allow configuration of another delimiter.

This also allows paging to be set to false. The commit which allows paging to be set to false 83091d0654f428624e6aa9493e2a8d4c356c5bff seems to have broken the build for python 2.6, but it is not clear to me how that broke.

I had been planning to do the unit tests for the new range feature, but ran out of time as I was building the application which uses this. After so much time has elapsed, I thought I would pass this on as it stands.
