### PR TITLE
Column list selection for DataTables API

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -62,7 +62,7 @@ class BaseTest(unittest.TestCase):
 
         for i, item in enumerate(columns):
             cols = 'columns[%s]' % i
-            params['%s%s' % (cols, '[data]')] = i
+            params['%s%s' % (cols, '[data]')] = item.mData or str(i)
             params['%s%s' % (cols, '[name]')] = ''
             params['%s%s' % (cols, '[searchable]')] = 'true'
             params['%s%s' % (cols, '[orderable]')] = 'true'
@@ -71,6 +71,6 @@ class BaseTest(unittest.TestCase):
 
         for i, item in enumerate(order or [{'column': 0, 'dir': 'asc'}]):
             for key, value in item.items():
-                params['order[%s][%s]' % (i, key)] = str(value)
+                params['order[%s][%s]' % (str(i), key)] = str(value)
 
         return params

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -30,6 +30,25 @@ class FieldsTest(BaseTest):
         assert 'Address' in res['data'][0]
         assert 'Created at' in res['data'][0]
 
+    def test_fields_mdata_subset(self):
+        """Test if it returns a subset of all columns."""
+        columns = [
+            ColumnDT(User.id, mData='ID'),
+            ColumnDT(User.name, mData='Username'),
+            ColumnDT(User.created_at, mData='Created at')]
+
+        query = self.session.query()
+
+        params = self.create_dt_params(columns[1:])
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        user = self.session.query(User).first()
+
+        assert len(res['data'][0]) == 2
+        assert 'Username' in res['data'][0]
+        assert 'Created at' in res['data'][0]
+
     def test_fields_search_filters(self):
         """Test if the result's data are filtered after search."""
         query = self.session.query()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -104,7 +104,7 @@ class FieldsTest2(BaseTest):
         assert len(res['data']) == 1
         assert res['recordsTotal'] == '52'
         assert res['recordsFiltered'] == '1'
-        assert res['data'][0]['1'] == 'User 51'
+        assert res['data'][0][1] == 'User 51'
 
 
 class FieldsTest3(BaseTest):
@@ -148,7 +148,7 @@ class FieldsTest3(BaseTest):
             assert len(res['data']) == 1
             assert res['recordsTotal'] == '1'
             assert res['recordsFiltered'] == '1'
-            assert res['data'][0]['1'] == 'Feeeeear Of'
+            assert res['data'][0][1] == 'Feeeeear Of'
 
 
 class FieldsTest4(BaseTest):

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -90,6 +90,47 @@ class ListingTest(BaseTest):
 
         assert len(res['data']) == 50
 
+    def test_list_subset(self):
+        """Test if it returns a subset of all columns."""
+        columns = [
+            ColumnDT(User.id),
+            ColumnDT(User.name),
+            ColumnDT(User.created_at)]
+
+        query = self.session.query()
+
+        params = self.create_dt_params(columns[:2])
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        user = self.session.query(User).first()
+
+        assert len(res['data'][0]) == 2
+        assert res['data'][0][0] == user.id
+        assert res['data'][0][1] == user.name
+
+    def test_list_reversed(self):
+        """Test if it returns a subset of all columns matching order in params list."""
+        columns = [
+            ColumnDT(User.name),
+            ColumnDT(User.id)]
+
+        query = self.session.query()
+
+        # Build params with columns[0][data]=1&columns[0][data]=0, returning (id,name)
+        params = self.create_dt_params(columns)
+        params['columns[0][data]']='1'
+        params['columns[1][data]']='0'
+
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        user = self.session.query(User).first()
+
+        assert len(res['data'][0]) == 2
+        assert res['data'][0][0] == user.name
+        assert res['data'][0][1] == user.id
+
 
 class ListingTest2(BaseTest):
 

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -123,8 +123,8 @@ class ListingTest2(BaseTest):
         res = rowTable.output_result()
 
         assert len(res['data']) == 1
-        assert res['data'][0]['1'] == 'Us'
-        assert res['data'][0]['2'] == 'User 51'
+        assert res['data'][0][1] == 'Us'
+        assert res['data'][0][2] == 'User 51'
 
 
 class ListingTest3(BaseTest):
@@ -158,5 +158,5 @@ class ListingTest3(BaseTest):
         assert len(res['data']) == 2
         assert res['recordsTotal'] == '52'
         assert res['recordsFiltered'] == '52'
-        assert res['data'][0]['0'] == 51
-        assert res['data'][1]['0'] == 52
+        assert res['data'][0][0] == 51
+        assert res['data'][1][0] == 52

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -47,7 +47,7 @@ class OrderingTest(BaseTest):
         rowTable = DataTables(params, query, columns)
         res = rowTable.output_result()
 
-        assert res['data'][0]['1'] == 'zzz_User'
+        assert res['data'][0][1] == 'zzz_User'
 
         # Ascending
         params = self.create_dt_params(columns,
@@ -56,7 +56,7 @@ class OrderingTest(BaseTest):
         rowTable = DataTables(params, query, columns)
         res = rowTable.output_result()
 
-        assert res['data'][0]['1'] == '000_User'
+        assert res['data'][0][1] == '000_User'
 
     def test_ordering_nulls(self):
         """Test if it returns a list with the correct nulls order."""
@@ -111,8 +111,8 @@ class OrderingTest(BaseTest):
         rowTable = DataTables(params, query, columns)
         res = rowTable.output_result()
 
-        assert res['data'][0]['1'] == 'UserLastAddress'
-        assert res['data'][0]['2'] == 'zzz_Address'
+        assert res['data'][0][1] == 'UserLastAddress'
+        assert res['data'][0][2] == 'zzz_Address'
 
         columns = [
             ColumnDT(User.id,),
@@ -127,5 +127,5 @@ class OrderingTest(BaseTest):
         rowTable = DataTables(params, query, columns)
         res = rowTable.output_result()
 
-        assert res['data'][0]['1'] == 'UserFirstAddress'
-        assert res['data'][0]['2'] == '000_Address'
+        assert res['data'][0][1] == 'UserFirstAddress'
+        assert res['data'][0][2] == '000_Address'

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -129,3 +129,57 @@ class OrderingTest(BaseTest):
 
         assert res['data'][0][1] == 'UserFirstAddress'
         assert res['data'][0][2] == '000_Address'
+
+    def test_with_named_order_column(self):
+        """Test with invalid order column."""
+        columns = [
+            ColumnDT(User.id, mData='id'),
+            ColumnDT(User.name, mData='name')]
+
+        query = self.session.query().select_from(User)
+
+        # Ascending by column index 1 == name
+        params = self.create_dt_params(columns,
+                                       order=[{"column": 1, "dir": "asc"}])
+
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        assert res['data'][0]['name'] == '000_User'
+
+    def test_with_named_order_column_reverse(self):
+        """Test with invalid order column."""
+        columns = [
+            ColumnDT(User.id, mData='id'),
+            ColumnDT(User.name, mData='name')]
+
+        query = self.session.query().select_from(User)
+
+        # Ascending by column index 0 == name
+        param_columns = columns[:]
+        param_columns.reverse()
+        params = self.create_dt_params(param_columns,
+                                       order=[{"column": 0, "dir": "asc"}])
+
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        assert res['data'][0]['name'] == '000_User'
+
+    def test_with_invalid_order_column(self):
+        """Test with invalid order column."""
+        columns = [
+            ColumnDT(User.id,),
+            ColumnDT(User.name)]
+
+        query = self.session.query().select_from(User)
+
+        # Column index 2
+        params = self.create_dt_params(columns,
+                                       order=[{"column": 2, "dir": "asc"}])
+
+        rowTable = DataTables(params, query, columns)
+        res = rowTable.output_result()
+
+        assert res['error'] == 'Invalid order column: 2'
+


### PR DESCRIPTION
Add support for column list selection using DataTables server-side API.

DataTables API is passing a list of columns (columns[i]) that may not match with the table definition on the server. For each request we build a list of columns as requested by the client, then use this list for building query. Columns with data source set to null or undefined are ignored, but searching and ordering column indexes are mapped to the column list in request. Returned results are labeled to match the request.

Returning nested data sources is not supported.